### PR TITLE
Feature/broker links

### DIFF
--- a/repositories/README.md
+++ b/repositories/README.md
@@ -10,13 +10,13 @@ Maven repository for open libraries from Fraunhofer IAIS. In this case
 - [get access](mailto:contact@ids.fraunhofer.de)
 ---
 
-## [IDS InformationModel](https://github.com/IndustrialDataSpace)
+## [IDS InformationModel](https://github.com/International-Data-Spaces-Association/InformationModel)
 [`IDS information model`, IDS-G glossary](../glossary/README.md#ids-information-model)
 - last click: 2020-01-16
 - stable release located at the master branch, the develop branch contains the working version
-- Find downloadable [releases](https://github.com/IndustrialDataSpace/InformationModel/releases)
+- Find downloadable [releases](https://github.com/International-Data-Spaces-Association/InformationModel/releases)
 - See the whole Information Model: Clone the repository and use [Protégé](https://protege.stanford.edu/) to open Ontology.ttl
-- found a bug or need more functionalities? [Submit an issue!](https://github.com/IndustrialDataSpace/InformationModel/issues)
+- found a bug or need more functionalities? [Submit an issue!](https://github.com/International-Data-Spaces-Association/InformationModel/issues)
 ---
 
 ## [ids-infomodel-demo, Fraunhofer IAIS](https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-demo/browse)

--- a/repositories/README.md
+++ b/repositories/README.md
@@ -7,6 +7,7 @@ In alphabetical order:
 Maven repository for open libraries from Fraunhofer IAIS. In this case
  especially for the Java implementation of the IDS Infomodel.
 - last click: 2020-01-16
+- [get access](mailto:contact@ids.fraunhofer.de)
 ---
 
 ## [IDS InformationModel](https://github.com/IndustrialDataSpace)

--- a/repositories/README.md
+++ b/repositories/README.md
@@ -13,6 +13,10 @@ Maven repository for open libraries from Fraunhofer IAIS. In this case
 ## [IDS InformationModel](https://github.com/IndustrialDataSpace)
 [`IDS information model`, IDS-G glossary](../glossary/README.md#ids-information-model)
 - last click: 2020-01-16
+- stable release located at the master branch, the develop branch contains the working version
+- Find downloadable [releases](https://github.com/IndustrialDataSpace/InformationModel/releases)
+- See the whole Information Model: Clone the repository and use [Protégé](https://protege.stanford.edu/) to open Ontology.ttl
+- found a bug or need more functionalities? [Submit an issue!](https://github.com/IndustrialDataSpace/InformationModel/issues)
 ---
 
 ## [ids-infomodel-demo, Fraunhofer IAIS](https://jira.iais.fraunhofer.de/stash/projects/ICTSL/repos/ids-infomodel-demo/browse)

--- a/shortcuts/README.md
+++ b/shortcuts/README.md
@@ -19,7 +19,7 @@
 |**`IDS-G`**    | [IDS Global](../README.md)
 |**`IDS-I`**    | *IDS Association* "Industrial Communitiy", [information under associations homepage](https://www.internationaldataspaces.org/idsa-industrial-community/)
 |**`IDS-IM`**   | IDS Information Model, [glossary](../glossary/README.md#ids-information-model), [GitHub repository)](https://github.com/International-Data-Spaces-Association/InformationModel)
-|**`IDS-MDB`**  | IDS Meta Data Broker
+|**`IDS-MDB`**  | IDS Meta Data Broker ([Specification Version 2.0](https://www.internationaldataspaces.org/wp-content/uploads/2020/09/IDSA-White-Paper-Specification-IDS-Meta-Data-Broker.pdf))
 |**`IDS-RAM`**  | IDS Reference Architecture Model, [glossary](../glossary/README.md#ids-reference-architecture-model), [IDS-RAM 3.0 (current version, PDF)](https://www.internationaldataspaces.org/wp-content/uploads/2019/03/IDS-Reference-Architecture-Model-3.0.pdf)
 |**`IDS-TSC`**  | IDS Technical Steering Committee
 |**`ParIS`**    | Participant Information Service, [glossary](../glossary/README.md#participant-information-service)


### PR DESCRIPTION
Adding:
* Link to the Broker Specification Document (no Jive-internal anymore)
* adding more info to the IM descriptions
* adding contact information for the IAIS Maven repo