### PR TITLE
Renaming "Usage Policy" to the better suited "Usage Control Language"…

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -7,4 +7,6 @@
 - [Clearing House](./ClearingHouse/README.md)
 - [IDS Technologies](./Technologies/README.md)
   - [Usage Control](./Technologies/UsageControl/README.md)
+    - [Contract](./Technologies/UsageControl/Contract/README.md)
+    - [Enforcement](./Technologies/UsageControl/Enforcement/README.md)
   - [IDS Communication Protocol (IDSCP)](./Technologies/idscp/README.md)

--- a/core/Technologies/UsageControl/Contract/README.md
+++ b/core/Technologies/UsageControl/Contract/README.md
@@ -1,0 +1,4 @@
+# IDS Usage Contact
+
+
+---

--- a/core/Technologies/UsageControl/Policy/README.md
+++ b/core/Technologies/UsageControl/Policy/README.md
@@ -1,4 +1,0 @@
-# IDS Usage Policy
-
-
----

--- a/core/Technologies/UsageControl/README.md
+++ b/core/Technologies/UsageControl/README.md
@@ -1,8 +1,8 @@
 # IDS Usage Control
 
-## IDS Usage Policy
+## IDS Usage Contract
 
-- [IDS-G specification "IDS Usage Policy"](./Policy/README.md)
+- [IDS-G specification "IDS Usage Contract"](./Contract/README.md)
 
 ---
 


### PR DESCRIPTION
… (for the previuously called "Policy Language") or "Usage Contract"