### PR TITLE
27 daps references

### DIFF
--- a/Components/IdentityProvider/Connector_Identities.md
+++ b/Components/IdentityProvider/Connector_Identities.md
@@ -1,0 +1,43 @@
+# Connector Identifiers (Connector IDs)
+
+Each connector in the IDS needs a valid, outlasting and unique identifier,
+never be re-used for any other resource inside the IDS ecosystem.
+
+The architecture aims to be open to multiple [Certificate Authorities](README.md) (CAs) issuing certificates.
+This means, a truly unique identifier needs to consist of the issuer of the certificate and the subject identifier.
+For an easy machine readable identifier, two ´X.509v3´ extensions will be used:
+
+* Subject Key Identifier (SKI)
+* Authority Key Identifier (AKI)
+
+The concatenation of ´SKI´ and ´AKI´ provides a unique identifier valid - even if multiple CAs are able to issue valid certificates.
+
+### Example
+The following is a snippet from a X.509 certificate in text format:
+
+```
+...
+X509v3 extensions:
+    X509v3 Subject Key Identifier:
+        DD:CB:FD:0B:93:84:33:01:11:EB:5D:94:94:88:BE:78:7D:57:FC:4A
+    X509v3 Authority Key Identifier:
+        keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50:2F:E6:65:43:5D:E8
+...
+```
+
+This leads to the unique [connector](../../Connector/README.md) identifier:
+
+```
+DD:CB:FD:0B:93:84:33:01:11:EB:5D:94:94:88:BE:78:7D:57:FC:4A:keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50:2F:E6:65:43:5D:E8
+```
+
+### Notes
+In examples and for reasons of readability editors might use
+
+```
+SKI:AKI
+```
+
+See also:
+- [X.509 certificates](https://en.wikipedia.org/wiki/X.509)
+

--- a/Components/IdentityProvider/DAPS/README.md
+++ b/Components/IdentityProvider/DAPS/README.md
@@ -45,8 +45,8 @@ It contains [JSON-LD](https://www.w3.org/TR/json-ld11/) data, and must additiona
 |:---|:---|
 |**@context**  | Must be `https://w3id.org/idsa/contexts/context.jsonld` |
 |**@type**     | Must be `ids:DatRequestToken` |
-|**sub**       | Must be the connector's ID |
-|**iss**       | Must be the connector's ID |
+|**sub**       | Must be the [connector's ID](../Connector_Identities.md) |
+|**iss**       | Must be the [connector's ID](../Connector_Identities.md) |
 |**aud**       | Must be `idsc:IDS_CONNECTORS_ALL` |
 |**iat**       | Must be present |
 |**nbf**       | Must equal **iat** |
@@ -83,10 +83,10 @@ which in turn contains [JSON-LD](https://www.w3.org/TR/json-ld11/) encoded data,
 |**@context**             | Must be `https://w3id.org/idsa/contexts/context.jsonld` |
 |**@type**                | Must be `ids:DatPayload` |
 |**iss**                  | Must be the DAPS URI |
-|**sub**                  | Must be the requesting connector's ID |
+|**sub**                  | Must be the requesting [connector's ID](../Connector_Identities.md) |
 |**exp**                  | Should be limited to a short time period (Recommendation: 1 hour) |
 |**nbf**                  | Must equal `iat` |
-|**aud**                  | Should include `idsc:IDS_CONNECTORS_ALL`. Alternatively, individual connector IDs may be specified. |
+|**aud**                  | Should include `idsc:IDS_CONNECTORS_ALL`. Alternatively, individual [connector IDs](../Connector_Identities.md) may be specified. |
 |**scope**                | Must include `idsc:IDS_CONNECTOR_ATTRIBUTES_ALL` |
 |**securityProfile**      | Must be an instance of the [`ids:SecurityProfile` class](https://w3id.org/idsa/core/SecurityProfile) |
 

--- a/Components/IdentityProvider/DAPS/README.md
+++ b/Components/IdentityProvider/DAPS/README.md
@@ -106,14 +106,14 @@ Therefore, the receiving party needs to connect the identity of a connector by r
 with its IDS identity claim of the DAT.
 The public transportation key must be one of the `transportCertsSha256` values.
 Otherwise, the receiving connector must expect that the requesting connector is using a false identity claim.
-Multiple values can be specified within a single string, separated by a single space character.
+In general, this claim holds an Array of Strings, but it may optionally hold a single String instead if the Array would have exactly one element.
 
 * **extendedGuarantee**
 In case a connector fulfills a certain security profile but deviates for a subset of attributes,
 it can inform the receiving connector about its actual security features.
 This can only happen if a connector reaches a higher level for a certain security attribute than the actual reached certification asks for.
 A deviation to lower levels is not possible, as this would directly invalidate the complete certification level.
-Multiple values can be specified within a single string, separated by a single space character.
+In general, this claim holds an Array of Strings, but it may optionally hold a single String instead if the Array would have exactly one element.
 
 
 ## Example

--- a/Components/IdentityProvider/DAPS/README.md
+++ b/Components/IdentityProvider/DAPS/README.md
@@ -1,18 +1,15 @@
 # Dynamic Attribute Provisioning Service (DAPS)
 
 The infrastructure component "Dynamic Attribute Provisioning Service" (DAPS)
- in a given IDS ecosystem enables enrichment of identities of organisations
- and connectors with additional attributes.
+in a given IDS ecosystem enables enrichment of identities of organisations
+and connectors with additional attributes.
 
 DAPS can be understood (like the [Certificate Authority](../CA/README.md), too) as building block of the construct of an
- [IDS Identity Provider](../../glossary/README.md#identity-provider).
-
-
+[IDS Identity Provider](../../glossary/README.md#identity-provider).
 
 These attributes are embedded by the DAPS into a [Dynamic Attribute Token (DAT)]().
- The advantages of this technique of *dynamic attribute provisioning* instead
- of embedding them into [X.509 certificates](https://en.wikipedia.org/wiki/X.509)
- are:
+The advantages of this technique of *dynamic attribute provisioning* instead
+of embedding them into [X.509 certificates](https://en.wikipedia.org/wiki/X.509) are:
 
 - Attribute revocation does not enforce certificate revocation and re-issuance.
  This is also true if new attributes are added.
@@ -24,161 +21,123 @@ These attributes are embedded by the DAPS into a [Dynamic Attribute Token (DAT)]
 - More complex scenarios can be created as soon as attributes are
  assigned later on.
 
-See also:
-- [Glossary "Dynamic Attribute Provisioning Service"](../../../Glossary/README.md#dynamic-attribute-provisioning-service)
-- Shortcut: `DAPS`
-
 ---
 
-## Unique Identifier
+## Token Request
 
-Each connector in the IDS needs a valid, outlasting and unique
- identifier, never be re-used for any other resource inside the IDS ecosystem.
+To request a Dynamic Attribute Token,
+a connector must send an [OAuth2 Access Token Request with a Client Credentials Grant Type](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)
+to the corresponding DAPS Token Endpoint.
+As authentication mechanism, a [JWT-Bearer-Token type](https://datatracker.ietf.org/doc/html/rfc7523#section-2.2) [Client Assertion](https://datatracker.ietf.org/doc/html/rfc7521#section-4.2) is used.
 
-The architecture aims to be open to multiple [Certificate Authorities](../CA/README.md)
- (CAs) issuing certificates. This means, a truly unique identifier needs to consist of
-  the issuer of the certificate and the subject identifier. For an easy machine readable
-  identifier, two ´X.509v3´ extensions will be used:
-
-### Subject Key Identifier (SKI)
-### Authority Key Identifier (AKI)
-
-The concatenation of ´SKI´ and ´AKI´ provides a unique identifier valid - even if multiple
- CAs are able to issue valid certificates.
-
-EXAMPLE (snippet from a X.509 certificate):
-
-```
-...
-X509v3 extensions:
-    X509v3 Subject Key Identifier:
-        DD:CB:FD:0B:93:84:33:01:11:EB:5D:94:94:88:BE:78:7D:57:FC:4A
-    X509v3 Authority Key Identifier:
-        keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50:2F:E6:65:43:5D:E8
-...
-```
-
-... leads to a [connectors](../../Connector/README.md) `unique identifier`:
-
-```
-DD:CB:FD:0B:93:84:33:01:11:EB:5D:94:94:88:BE:78:7D:57:FC:4A:keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50:2F:E6:65:43:5D:E8
-```
-
-In examples and for reasons of readability editors might use
-
-```
-SKI:AKI
-```
-
-See also:
-- [Glossary "Dynamic Attribute Token"](../../../Glossary/README.md#dynamic-attribute-token)
-- Shortcut: `DAT`
-- [X.509 certificates](https://en.wikipedia.org/wiki/X.509)
-
----
-
-
-## Request token that is handed in at DAPS side
-
-|**Field name**|**mandantory**|**cardinality**|**content**
-|:---|:---|:---|:---|
-|**`@context`**  | yes   | 1 | The JSON-LD context containing the IDS classes, properties and instances. Must be "https://w3id.org/idsa/contexts/context.jsonld". |
-|**`@type`**     | yes   | 1 | In the context of the IDS, the request payload is an RDF instance and therefore must state that it has "@type" : "ids:DatRequestToken". |
-|**`sub`**       | yes   | 1 | Subject the requesting connector the token is created for. This is the connector requesting the DAT. The "sub" value must be the  combined entry of the SKI and AKI of the IDS X509 as presented in Sec. 4.2.1.  In this context, this is identical to "iss". |
-|**`exp`**       | yes   | 1 | Expiration date of the token. Can be chosen freely but should be limited to a short period of time (e.g., one minute). |
-|**`iat`**       | yes   | 1 | Timestamp the token has been issued. |
-|**`nbf`**       | yes   | 1 | "Valid not before": For practical reasons this should be identical to iat. If the system time is not in synch with the DAPS, the request token will be rejected (e.g., nbf is in the future). |
-|**`aud`**       | yes   | 1 | The audience of the token. This can limit the validity for certain connectors. |
-|**`iss`**       | yes   | 1 | According to RFC 7519 Sec. 4.1.1, the issuer is the component which created and signed the JWT. In the context of the IDS, this must be a valid connector. The "iss" value must be the combined entry of the SKI and AKI of the Connectors X509 certificate as presented in Sec. 4.2.1. |
-
-
-
-## Request call to get a token
-
-`client_assertion` is the base64 encoded request token, shown under
- ["Request token that is handed in at DAPS side"](#request-token-that-is-handed-in-at-daps-side).
-
+Additionally, the following restrictions must be met within the request parameters:
 
 |**FormBody Attribute**|**content**
 |:---|:---|
-|**`grant_type`**  | OAuth based grant type. Always uses client_credentials grant. |
-|**`client_assertion_type`**  | See [JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://tools.ietf.org/html/rfc7523). |
-|**`client_assertion`**  | The signed and base64 encoded request token. Paste the example to jwt.io to see the decoded JWT. The token is signed with the connectors private key belonging to the public key contained in the X.509 certificate. |
+| **scope** | Must include `idsc:IDS_CONNECTOR_ATTRIBUTES_ALL` |
+| **client_id** | Must be the connector's ID |
+| **client_assertion** | Must be Base64-encoded, signed using the key pre-registered at the DAPS, and contain the claims described below |
 
+The JWT-Bearer itself adheres to [RFC 7519](https://www.rfc-editor.org/rfc/rfc7519) and [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515) in particular.
+It contains [JSON-LD](https://www.w3.org/TR/json-ld11/) data, and must additionally contain all of the following claims:
 
-### Example of a "request call to get a token"
+|**Field name**|**additional restrictions**
+|:---|:---|:---|:---|
+|**@context**  | Must be `https://w3id.org/idsa/contexts/context.jsonld` |
+|**@type**     | Must be `ids:DatRequestToken` |
+|**sub**       | Must be the connector's ID |
+|**iss**       | Must be the connector's ID |
+|**aud**       | Must be `idsc:IDS_CONNECTORS_ALL` |
+|**iat**       | Must be present |
+|**nbf**       | Must equal **iat** |
+|**exp**       | Should be limited to a short time period (Recommendation: 1 Minute) |
+
+Future revisions of this document may allow for differing audiences and additional parameters.
+
+### Example
+
+The following is a non-normative and abbreviated example of a DAT request.
+Line breaks are purely for readability purposes.
 
 ```http request
-POST /
+POST /token
 Host: https://daps.example.com
 Content-Type: application/x-www-form-urlencoded
-"grant_type=client_credentials
- &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
- &client_assertion=eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJkZW1vY29ubmVjdG9yMSIsInN1YiI6ImRlbW9jb25uZWN0b3IxIiwiZXhwIjoxNTQ4Nzg1Mzg2LCJuYmYiOjE1NDg3ODE3ODYsImlhdCI6MTU0ODc4MTc4NiwiYXVkIjoiaHR0cHM6Ly9hcGkubG9jYWxob3N0In0.JSQuMf-9Fd7DNna_-s-sR7eXgcSYNCau5WgurrGJTuCSLKqhZe3odXfunN2vRFgUhU21ADFlEq96mlbQDueBlMtaXrcHFPSpIUtvuIMIVqQcGYkDdSJr_VmDuAykCYpyTCkLa7a8DTV-N3sECp-AxUgmEzYIfh8jW0WS6ehgUzrnpH6t_h_GWXKkNSAg3ERakDc4NY02pBGmiN7bmtLZNt5b4LWALiiFiduC7JbIpx4awOU6skMApmzgLnZmmTG20JlJRg6hAqyHEz5Cd4rUgrt0twmpC0Us_CG23KdUF5fWI55dcO2qAVvhNQXpqz7IiPcF7-jgkrx4oukYNY6eHA"
- &scope=ids_connector_attributes"
 
+grant_type=client_credentials
+&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+&client_assertion=eyJhbGciOiJSUzI1NiJ9.eyJ[...]N0In0.JSQu[...]gkrx4oukYNY6eHA
+&scope=ids_connector_attributes
 ```
-
-> **!!!** REMARK: NO line breaks in front of '&', done for better readability only **!!!**
-
-See also:
-- [JSON-LD](https://en.wikipedia.org/wiki/JSON-LD)
-- [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
 
 ---
 
+## Token Response
 
-## Dynamic Attribute Token Content
+The DAPS issues the requested DAT, or an error response, as per [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-5).
+The Access Token ("the DAT") itself is a JWT adhering to [RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068),
+which in turn contains [JSON-LD](https://www.w3.org/TR/json-ld11/) encoded data, subject to the following additional constraints:
 
-The DAPS issues the requested DAT, if authentication succeeds, embedded in a JSON Object under the key _access_token_, e.g.
+|**Field name**|**additional constraints**
+|:---|:---|:---|:---|
+|**@context**             | Must be `https://w3id.org/idsa/contexts/context.jsonld` |
+|**@type**                | Must be `ids:DatPayload` |
+|**iss**                  | Must be the DAPS URI |
+|**sub**                  | Must be the requesting connector's ID |
+|**exp**                  | Should be limited to a short time period (Recommendation: 1 hour) |
+|**nbf**                  | Must equal `iat` |
+|**aud**                  | Should include `idsc:IDS_CONNECTORS_ALL`. Alternatively, individual connector IDs may be specified. |
+|**scope**                | Must include `idsc:IDS_CONNECTOR_ATTRIBUTES_ALL` |
+|**securityProfile**      | Must be an instance of the [`ids:SecurityProfile` class](https://w3id.org/idsa/core/SecurityProfile) |
 
-```
+Future revisions of this document may allow for mechanisms to specify connectors to be listed in the `aud` claim such as through [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707).
+
+Additional claims may optionally be present. This specification defines the following:
+
+* **referringConnector**
+An optional URI of the subject.
+Is used to connect identifier of the connector with the self-description identifier as defined by the IDS Information Model.
+A receiving connector can use this information to request more information at a Broker or directly by dereferencing this URI.
+
+* **transportCertsSha256**
+Contains the public keys of the used transport certificates, hashed using SHA256.
+The identifying X509 certificate should not be used for the communication encryption.
+Therefore, the receiving party needs to connect the identity of a connector by relating its hostname (from the communication encryption layer) and the used private/public key pair,
+with its IDS identity claim of the DAT.
+The public transportation key must be one of the `transportCertsSha256` values.
+Otherwise, the receiving connector must expect that the requesting connector is using a false identity claim.
+Multiple values can be specified within a single string, separated by a single space character.
+
+* **extendedGuarantee**
+In case a connector fulfills a certain security profile but deviates for a subset of attributes,
+it can inform the receiving connector about its actual security features.
+This can only happen if a connector reaches a higher level for a certain security attribute than the actual reached certification asks for.
+A deviation to lower levels is not possible, as this would directly invalidate the complete certification level.
+Multiple values can be specified within a single string, separated by a single space character.
+
+
+## Example
+
+The following is an example of a sucessful response:
+
+```http response
+200 This is fine
+Content-Type: application/json
+
 {
-    "access_token": "<DAT>",
-    "scope": "ids_connector_attributes",
+    "access_token": "skdj54dkGjnb[...]lsl8723ijsdfuzticby_ch",
+    "scope": "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL",
     "token_type": "bearer",
     "expires_in": "3600"
 }
 ```
 
-For details about this format, please refer to [RFC 6749, Section 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1)
+The decoded DAT, including header and payload is shown below:
 
-The DAT itself is represented as an encoded JSON Web Token.
-Decoded it has these header fields:
-
-|**Field name**|**mandantory**|**cardinality**|**content**
-|:---|:---|:---|:---|
-|**`typ`**             | yes    | 1    | The token type. Must be "JWT". |
-|**`kid`**             | yes    | 1    | Key id used to sign that token. Must match the jwks.json entry found at daps-url/.well-known/jwks.json |
-|**`alg`**             | yes    | 1    | Algorithm used to sign the token.   |
-
-The DAT has these payload fields:
-
-|**Field name**|**mandantory**|**cardinality**|**content**
-|:---|:---|:---|:---|
-|**`@context`**             | yes    | 1    | The JSON-LD context containing the IDS classes, properties and instances. Must be "https://w3id.org/idsa/contexts/context.jsonld". |
-|**`@type`**                | yes    | 1    | In the context of the IDS, the request payload is an RDF instance and therefore must state that it has "@type" : "ids:DatRequestToken".
-|**`iss`**                  | yes    | 1    | According to RFC 7519 Sec. 4.1.1, the issuer is the component which created and signed the JWT. In the context of the IDS, this must be a valid DAPS. The "iss" value must be a valid URL for the DAPS such as "https://daps.aisec.fraunhofer.de".  |
-|**`sub`**                  | yes    |      | Subject the requesting connector the token is created for. This is the connector requesting the [DAT](#dynamic-attribute-token-dat). The `sub` value must be the  combined entry of the `SKI` and `AKI` of the IDS X509 as presented in Sec. 4.2.1.  In this context, this is identical to `iss`. |
-|**`exp`**                  | yes    | 1    | Expiration date of the token. Can be chosen freely but should be limited to a short period of time (e.g., one minute).  |
-|**`iat`**                  | yes    | 1    | Timestamp the token has been issued.  |
-|**`nbf`**                  | yes    | 1    | "Valid not before" (`nbf`): for practical reasons this should be identical to `iat`. If systems time is not aynchronized with the DAPS, the request token will be rejected (so, `nbf` is in the future).  |
-|**`aud`**                  | yes    | 1    | The audience of the token. This can limit the validity for certain connectors. |
-|**`scope`**                | yes    | 1..* | List of scopes. Currently, the scope is limited to "ids_connector_attributes" but can be used for scoping purposes in the future. |
-|**`securityProfile`**      | yes    | 1    | States that the requesting connector conforms to a certain security profile and has been certified to do so. The value must be an URI, in particular an instance of the ids:SecurityProfile class. |
-|**`referringConnector`**   | `opt`  | 0..1 | The URI of the subject, the connector represented by the DAT. Is used to connect identifier of the connector with the self-description identifier as defined by the IDS Information Model. A receiving connector can use this information to request more information at a Broker or directly by dereferencing this URI. |
-|**`transportCertsSha256`** | `opt`  | 0..* | Contains the public keys of the used transport certificates. The identifying X509 certificate should not be used for the communication encryption. Therefore, the receiving party needs to connect the identity of a connector by relating its hostname (from the communication encryption layer) and the used private/public key pair, with its IDS identity claim of the DAT. The public transportation key must be one of the "transportCertsSha256" values. Otherwise, the receiving connector must expect that the requesting connector is using a false identity claim. |
-|**`extendedGuarantee`**    | `opt`  | 0..* | In case a connector fulfills a certain security profile but deviates for a subset of attributes, it can inform the receiving connector about its actual security features. This can only happen if a connector reaches a higher level for a certain security attribute than the actual reached certification asks for. A deviation to lower levels is not possible, as this would directly invalidate the complete certification level. |
-
-
-## Dynamic Attribute Token (DAT)
-
-An example of a complete decoded DAT, including header and payload is shown below:
-
-```
+```json
 {
-    "typ": "JWT",
-    "kid": "default",
+    "typ": "jwt+at",
+    "kid": "somekid",
     "alg": "HS256"
 }
 .
@@ -187,34 +146,25 @@ An example of a complete decoded DAT, including header and payload is shown belo
     "@type": "ids:DatPayload",  
     "iss": "https://daps.aisec.fraunhofer.de",
     "sub": "DD:CB:FD:0B:93:84:33:01:11:EB:5D:94:94:88:BE:78:7D:57:FC:4A:keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50:2F:E6:65:43:5D:E8",
+    "nbf": 1516239022,
+    "iat": 1516239022,
+    "exp": 1516239032,
+    "aud": ["idsc:IDS_CONNECTORS_ALL"],
+    "scope": "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL"
     "referringConnector": "http://some-connector-uri.com",
     "securityProfile": "idsc:BASE_SECURITY_PROFILE",
     "extendedGuarantee": "idsc:USAGE_CONTROL_POLICY_ENFORCEMENT",
-    "transportCertsSha256": ["bacb879575730bb083f283fd5b67a8cb..." ],
-    "iat": 1516239022,
-    "exp": 1516239032,
-    "aud": "https://w3id.org/idsa/code/IDS_CONNECTORS_ALL",
-    "nbf": 1567703561,
-    "scope": "ids_connector_attributes"
+    "transportCertsSha256": "bacb879575730bb083f283fd5b67a8cb..."
 }
 .
-<signature>
+somesignature
 ```
 
 See also:
-- [Info Model : idsc:USAGE_CONTROL_POLICY_ENFORCEMENT](https://github.com/International-Data-Spaces-Association/InformationModel/blob/develop/codes/SecurityGuarantee.ttl)
+- [Glossary "Dynamic Attribute Provisioning Service"](../../../Glossary/README.md#dynamic-attribute-provisioning-service)
 - [Glossary "Dynamic Attribute Token"](../../../Glossary/README.md#dynamic-attribute-token)
-- Shortcut: `DAT`
+- [Info Model : idsc:USAGE_CONTROL_POLICY_ENFORCEMENT](https://github.com/International-Data-Spaces-Association/InformationModel/blob/develop/codes/SecurityGuarantee.ttl)
+- [JSON-LD](https://en.wikipedia.org/wiki/JSON-LD)
+- [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
+- Shortcuts: `DAT`, `DAPS`
 
----
-
-## Requests
-
-Collection of valid request templates can be found [here](./requests/README.md).
-
-## REST API description
-
-REST API description can be found
- [here](https://app.swaggerhub.com/apis/IDS_Association/DynamicAttributeProvisioningService).
-
----

--- a/Components/IdentityProvider/DAPS/README.md
+++ b/Components/IdentityProvider/DAPS/README.md
@@ -42,7 +42,7 @@ The JWT-Bearer itself adheres to [RFC 7519](https://www.rfc-editor.org/rfc/rfc75
 It contains [JSON-LD](https://www.w3.org/TR/json-ld11/) data, and must additionally contain all of the following claims:
 
 |**Field name**|**additional restrictions**
-|:---|:---|:---|:---|
+|:---|:---|
 |**@context**  | Must be `https://w3id.org/idsa/contexts/context.jsonld` |
 |**@type**     | Must be `ids:DatRequestToken` |
 |**sub**       | Must be the connector's ID |
@@ -78,8 +78,8 @@ The DAPS issues the requested DAT, or an error response, as per [RFC 6749](https
 The Access Token ("the DAT") itself is a JWT adhering to [RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068),
 which in turn contains [JSON-LD](https://www.w3.org/TR/json-ld11/) encoded data, subject to the following additional constraints:
 
-|**Field name**|**additional constraints**
-|:---|:---|:---|:---|
+|**Field name**|**additional constraints** |
+|:---|:---|
 |**@context**             | Must be `https://w3id.org/idsa/contexts/context.jsonld` |
 |**@type**                | Must be `ids:DatPayload` |
 |**iss**                  | Must be the DAPS URI |


### PR DESCRIPTION
This PR adresses Issue #27 by rewriting and restructuring the DAPS Specification.
It also separates the Connector IDs into their own file for later reference from other files.