### PR TITLE
Update to Clearing House documentation

### DIFF
--- a/Communication/README.md
+++ b/Communication/README.md
@@ -8,7 +8,7 @@
 | [2]  | Connector to Dynamic Attribute Provisioning Service (DAPS) |  |
 | [3]  | Connector to Participant Information Service (ParIS) |  |
 | [4]  | Connector to [Metadata Broker](./sequence-diagrams/data-connector-to-metadata-broker) | [Multipart](./protocols/multipart) |
-| [5]  | [Connector to Clearing House](./sequence-diagrams/data-connector-to-clearing-house) | [Multipart](./protocols/multipart) |
+| [5]  | [Connector to Clearing House](./sequence-diagrams/data-connector-to-clearing-house) | [Multipart](./protocols/multipart), [IDSCP2](./protocols/idscp2/ApplicationLayer)|
 | [6]  | Connector to App Store |  |
 | [7]  | Connector to Vocabulary Provider |  |
 | [8]  | ParIS to DAPS |  |

--- a/Communication/protocols/idscp2/ApplicationLayer/README.md
+++ b/Communication/protocols/idscp2/ApplicationLayer/README.md
@@ -34,3 +34,109 @@ The IDSCP2 App Layer Protocol uses exactly this message definition for IDS messa
 ## IDSCP2 Message Types
 The message type is held within the header field called ‘idscp2.type’. Since it simply contains a serialization for the IDS Information Model Messages in JSON-LD, any defined IDS Message types can be supported.
 Some examples for headers and payloads can be found [here](./Examples.md).
+
+## Clearing House Interactions
+Connectors can interact with the Clearing House using the IDSCP2 App Layer Protocol. The Clearing House accepts the IDS message types [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl), [QueryMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) and [RequestMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl). In most cases, the Clearing House expects additional headers. The following sections detail the possible interactions and list the expected headers as well as the results.
+
+### Creating a Processes
+The IDS Clearing House structures its logs into processes and requires that all messages are logged under a process id. Processes are meant to represent agreed upon data exchanges that include the storage of the contract agreement and all messages that document the data exchange. Processes can be created by any IDS connector with a valid DAT, who becomes the owner of the process. Additional owners can be defined in the parameters of the request. Only owners of the process may read or write log entries for the process. The Clearing House expects a [RequestMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) to create a process id.
+
+#### Additional Headers
+|Name|Type|Required|Description|
+|---|---|---|---|
+|ch-ids-pid|string|true|The unique identifier of the process that will be used for logging all information connected to the process|
+|Content-Type|string|true|The Clearing House expects the content type "application/json"|
+
+#### Expected Response
+|Message|Meaning|Description|
+|---|---|---|
+|[MessageProcessedNotificationMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Created | The unique identifier has been created and is sent back as the payload.|
+|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Error | An error occurred. The payload contains an HTTP error code.|
+
+
+### Logging messages
+To log information in the Clearing House a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) must be sent. The payload contains the information that should be logged. The log entry stored in the Clearing House under the given process *pid*. Returns a signed receipt of the logged data in form of a JSON Web Token (JWT) as payload of the response.
+
+#### Additional Headers
+|Name|Type|Required|Description|
+|---|---|---|---|
+|ch-ids-pid|string|true|The unique identifier of the process under which the data should be logged|
+
+#### Expected Response
+|Message|Meaning|Description|
+|---|---|---|
+|[MessageProcessedNotificationMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Created | The payload contains the signed receipt of the logged data in form of a JWT.|
+|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Error | An error occurred. The payload contains an HTTP error code.|
+
+### Query multiple messages of a process
+The Clearing House expects a [QueryMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) to retrieve multiple log entries. Pagination is enforced, so retrieving all log entries might require multiple requests. When querying the Clearing House the query may contain the requested *page* of data, the *size* of the requested page, and the sorting *order* of the results. The Clearing House answers the request with a [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl). The payload contains the log entries found, as well as the pagination information *page*, *size* and *order* that were used in the request. Each log entry is returned as a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl).
+
+#### Additional Headers
+|Name|Type|Required|Description|
+|---|---|---|---|
+|ch-ids-pid|string|true| The unique identifier of the process under which the log entry was created|
+|ch-ids-page|string|false|The requested result page. Defaults to 1|
+|ch-ids-size|string|false|The size of the requested result page. Defaults to 100|
+|ch-ids-sort|string|false|The order of the requested results. Defaults to "desc"|
+|Content-Type|string|true|The Clearing House expects the content type "application/json"|
+
+#### Expected Response
+|Message|Meaning|Description|
+|---|---|---|
+|[ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Ok | The Clearing House sends back a JSON containing both pagination information and an array of log entries in the form of [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Error | An error occurred. The payload contains an HTTP error code.|
+
+
+The following example illustrates the payload sent by the Clearing House as an answer to a QueryMessage for multiple log entries:
+```json
+{
+  "date_from": "2022-09-13 00:00:00",
+  "date_to": "2022-09-27 15:40:02",
+  "page": 2,
+  "size": 5,
+  "order": "asc",
+  "documents": [{
+    "@context": {
+      "idsc": "https://w3id.org/idsa/code/",
+      "ids": "https://w3id.org/idsa/core/"
+    },
+    "@type": "ids:LogMessage",
+    "@id": "https://w3id.org/idsa/autogen/logMessage/c6c15a90-7799-4aa1-ac21-9323b87a7xv9",
+    "ids:modelVersion": "4.1.0",
+    "ids:issued": "2021-07-20T12:50:04.916267339+00:00",
+    "ids:issuerConnector": "https://provider.ids.isst.fraunhofer.de/",
+    "ids:senderAgent": "http://example.org",
+    "payload": "\"YXNhZnNzd2V3c2Vyd2VmcndlZnJ3ZWZydw==\"",
+    "payload_type": "\"text/plain\""
+  },
+  {
+    "@context": {
+      "idsc": "https://w3id.org/idsa/code/",
+      "ids": "https://w3id.org/idsa/core/"
+    },
+    "@type": "ids:LogMessage",
+    "@id": "https://w3id.org/idsa/autogen/logMessage/c6c15a90-7799-4aa1-ac21-9323b87a7xv9",
+    "ids:modelVersion": "4.1.0",
+    "ids:issued": "2021-07-20T12:50:04.916327776+00:00",
+    "ids:issuerConnector": "https://consumer.ids.isst.fraunhofer.de/",
+    "ids:senderAgent": "http://example.org",
+    "payload": "\"YXNhZnNzd2V3c2Vyd2VmcndlZnJ3ZWZydw==\"",
+    "payload_type": "\"text/plain\""
+}]}
+```
+
+### Query a single message of a process
+Retrieves the log entry that is stored under the given *id* and the given process *pid* in the Clearing House. The Clearing House answers the request with a [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) that contains as the payload the log entry found. The log entry is returned as a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl), i.e., the payload of the [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) contains a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl).
+
+#### Additional Headers
+|Name|Type|Required|Description|
+|---|---|---|---|
+|ch-ids-pid|string|true| The unique identifier of the process under which the log entry was created|
+|ch-ids-id|string|true|The unique identifier of the log entry requested|
+|Content-Type|string|true|The Clearing House expects the content type "application/json"|
+
+#### Expected Response
+|Message|Meaning|Description|
+|---|---|---|
+|[ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Ok | The Clearing House sends back the requested log entry in the form of [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)| Error | An error occurred. The payload contains an HTTP error code.|

--- a/Communication/protocols/multipart/README.md
+++ b/Communication/protocols/multipart/README.md
@@ -377,7 +377,7 @@ The default interaction protocol for the IDS Clearing House is HTTPS. Any IDS Cl
 
 
 #### 4.2.2 Creating a Processes
-The IDS Clearing House structures its logs into processes and requires that all messages are logged under a process id. Processes are meant to represent agreed upon data exchanges that include the storage of the contract agreement and all messages that document the data exchange. Processes can be created by any IDS connector with a valid DAT, who becomes the owner of the process. Additional owners can be defined in the parameters of the request. Only owners of the process may read or write log entries for the process.
+The IDS Clearing House structures its logs into processes and requires that all messages are logged under a process id. Processes are meant to represent agreed upon data exchanges that include the storage of the contract agreement and all messages that document the data exchange. Processes can be created by any IDS connector with a valid DAT, who becomes the owner of the process. Additional owners can be defined in the parameters of the request. Only owners of the process may read or write log entries for the process. The Clearing House expects a [RequestMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) in the header part of the multipart message.
 
 |Request method | Description |
 |---|---|
@@ -387,18 +387,20 @@ The IDS Clearing House structures its logs into processes and requires that all 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |pid|path|string|true|The unique identifier of the process that will be used for logging all information connected to the process|
+|header-part|body|json-ld|true| The header part of the multi-part message must contain a [RequestMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
 |owners|body|json|false|A list of owners that may log and access data in the given pid|
 
 #### Response Codes
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[MessageProcessedNotificationMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[MessageProcessedNotificationMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Forbidden|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
 
 #### 4.2.3 Logging messages
-The information that should be logged in the Clearing House (*logData*) is sent in the payload of a [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure). The log entry stored in the Clearing House consists of the payload and meta-data from the [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) and is stored under the given process *pid*. Returns a signed receipt of the logged data in form of a JSON Web Token (JWT) as payload of the response.
+The information that should be logged in the Clearing House (*logData*) is sent in the payload of a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl). The log entry stored in the Clearing House consists of the payload and meta-data from the [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) and is stored under the given process *pid*. Returns a signed receipt of the logged data in form of a JSON Web Token (JWT) as payload of the response.
 
 |Request method | Description |
 |---|---|
@@ -408,15 +410,17 @@ The information that should be logged in the Clearing House (*logData*) is sent 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |pid|path|string|true|Process id under which the message should be logged.|
-|logData|body|[LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|true|[LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) with information that should be logged in the payload|
+|header-part|body|json-ld|true| The header part of the multi-part message must contain a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|*logData*|body|String|true| The payload part of the multi-part message contains the information that should be logged in the Clearing House|
 
 #### Response Codes
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[MessageProcessedNotificationMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[MessageProcessedNotificationMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Forbidden|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
 
 #### Example Http Multipart Request
 ```http
@@ -471,8 +475,8 @@ Content-Type: application/json
 --X-TEST-REQUEST-BOUNDARY--
 ```
 
-#### 4.2.4 Query all messages of a process
-Retrieves all log entries that are stored under the given *pid* in the Clearing House. The Clearing House answers the request with a [ResultMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) that contains as the payload all log entries found. Each log entry is returned as a [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure), i.e., the payload of the [ResultMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) contains a `json` array of [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure).
+#### 4.2.4 Query multiple messages of a process
+Retrieves multiple log entries that are stored under the given *pid* in the Clearing House. Pagination is enforced, so retrieving all log entries might require multiple requests. When querying the Clearing House the query may contain the requested *page* of data, the *size* of the requested page, and the sorting *order* of the results. The Clearing House answers the request with a [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) that contains in the payload the log entries found, as well as the pagination information *page*, *size* and *order* that were used in the request. Each log entry is returned as a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl), i.e., the payload of the [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) contains a `json` array of [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl).
 
 |Request method | Description |
 |---|---|
@@ -482,15 +486,19 @@ Retrieves all log entries that are stored under the given *pid* in the Clearing 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |pid|path|string|true|Process id under which the log entry is stored|
-|query|body|[QueryMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|true|[QueryMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
+|page|query|uint|false|Requested result page number of log entries|
+|size|query|uint|false|Expected size of result page (defaults to 100)|
+|sort|query|string|false|Sorting order of the results. Allowed either "asc" or "desc". Defaults to "desc"|
+|header-part|body|json-ld|true| The header part of the multi-part message must contain a [QueryMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
 
 #### Response Codes
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful operation|[ResultMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) containing a `json` array of [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful operation|[ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) containing a `json` array of [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Forbidden|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
 
 The following example illustrates an answer of the Clearing House to a multipart request with a QueryMessage:
 ```http
@@ -554,8 +562,13 @@ content-transfer-encoding: 8bit
 content-disposition: form-data; name="payload"
 content-type: application/json
 content-transfer-encoding: 8bit
-[
-  {
+{
+  "date_from": "2022-09-13 00:00:00",
+  "date_to": "2022-09-27 15:40:02",
+  "page": 2,
+  "size": 5,
+  "order": "asc",
+  "documents": [{
     "@context": {
       "idsc": "https://w3id.org/idsa/code/",
       "ids": "https://w3id.org/idsa/core/"
@@ -582,13 +595,12 @@ content-transfer-encoding: 8bit
     "ids:senderAgent": "http://example.org",
     "payload": "\"YXNhZnNzd2V3c2Vyd2VmcndlZnJ3ZWZydw==\"",
     "payload_type": "\"text/plain\""
-  }
-]
+}]}
 --336749cd-8331-46b4-b75d-d9d2ae80e3ac--
 ```
 
 #### 4.2.5 Query a single message of a process
-Retrieves the log entry that is stored under the given *id* and the given process *pid* in the Clearing House. The Clearing House answers the request with a [ResultMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) that contains as the payload the log entry found. The log entry is returned as a [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure), i.e., the payload of the [ResultMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) contains a [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure).
+Retrieves the log entry that is stored under the given *id* and the given process *pid* in the Clearing House. The Clearing House answers the request with a [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) that contains as the payload the log entry found. The log entry is returned as a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl), i.e., the payload of the [ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) contains a [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl).
 
 |Request method | Description |
 |---|---|
@@ -599,12 +611,13 @@ Retrieves the log entry that is stored under the given *id* and the given proces
 |---|---|---|---|---|
 |pid|path|string|true|Process id under which the log entry is stored|
 |id|path|string|true|Id of the log entry|
-|query|body|[QueryMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|true|[QueryMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
+|header-part|body|json-ld|true| The header part of the multi-part message must contain a [QueryMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
 
 #### Response Codes
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful operation|[ResultMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure) containing a `json` array of [LogMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
-|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/IDS-G-pre/tree/connector-interaction/Communication/Message-Structure)|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful operation|[ResultMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl) containing a `json` array of [LogMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|Forbidden|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Error|[RejectionMessage](https://github.com/International-Data-Spaces-Association/InformationModel/blob/v4.1.0/taxonomies/Message.ttl)|


### PR DESCRIPTION
I updated the Connector interaction with the Clearing House for both multipart and IDSCP2 protocol. The biggest change is that the Clearing House now answers queries using pagination. Smaller changes include new improved error codes.